### PR TITLE
Grammar fix: "torpedos" -> "torpedoes"

### DIFF
--- a/src/main/java/hu/bme/mit/spaceship/GT4500.java
+++ b/src/main/java/hu/bme/mit/spaceship/GT4500.java
@@ -1,7 +1,7 @@
 package hu.bme.mit.spaceship;
 
 /**
-* A simple spaceship with two proton torpedos and four lasers
+* A simple spaceship with two proton torpedoes and four lasers
 */
 public class GT4500 implements SpaceShip {
 
@@ -34,7 +34,7 @@ public class GT4500 implements SpaceShip {
   * @return whether at least one torpedo was fired successfully
   */
   @Override
-  public boolean fireTorpedos(FiringMode firingMode) {
+  public boolean fireTorpedoes(FiringMode firingMode) {
 
     boolean firingSuccess = false;
 
@@ -77,7 +77,7 @@ public class GT4500 implements SpaceShip {
         break;
 
       case ALL:
-        // try to fire both of the torpedos
+        // try to fire both of the torpedoes
         //TODO implement feature
 
         break;

--- a/src/main/java/hu/bme/mit/spaceship/SpaceShip.java
+++ b/src/main/java/hu/bme/mit/spaceship/SpaceShip.java
@@ -15,10 +15,10 @@ public interface SpaceShip {
   public boolean fireLasers(FiringMode firingMode);
 
   /**
-  * Fires the torpedos of the ship
+  * Fires the torpedoes of the ship
   *
   * @param firingMode how many torpedo bays to fire
   * @return whether the fire command was successful
   */
-  public boolean fireTorpedos(FiringMode firingMode);
+  public boolean fireTorpedoes(FiringMode firingMode);
 }

--- a/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
+++ b/src/main/java/hu/bme/mit/spaceship/TorpedoStore.java
@@ -3,20 +3,20 @@ package hu.bme.mit.spaceship;
 import java.util.Random;
 
 /**
-* Class storing and managing the torpedos of a ship
+* Class storing and managing the torpedoes of a ship
 */
 public class TorpedoStore {
 
-  private int torpedos = 0;
+  private int torpedoes = 0;
   private Random generator = new Random();
 
-  public TorpedoStore(int numberOfTorpedos){
-    this.torpedos = numberOfTorpedos;
+  public TorpedoStore(int numberOfTorpedoes){
+    this.torpedoes = numberOfTorpedoes;
   }
 
-  public boolean fire(int numberOfTorpedos){
-    if(numberOfTorpedos < 1 || numberOfTorpedos > this.torpedos){
-      throw new IllegalArgumentException("numberOfTorpedos");
+  public boolean fire(int numberOfTorpedoes){
+    if(numberOfTorpedoes < 1 || numberOfTorpedoes > this.torpedoes){
+      throw new IllegalArgumentException("numberOfTorpedoes");
     }
 
     boolean success = false;
@@ -26,7 +26,7 @@ public class TorpedoStore {
 
     if (r > 0.01) {
       // successful firing
-      this.torpedos -= numberOfTorpedos;
+      this.torpedoes -= numberOfTorpedoes;
       success = true;
     } else {
       // failure
@@ -37,10 +37,10 @@ public class TorpedoStore {
   }
 
   public boolean isEmpty(){
-    return this.torpedos <= 0;
+    return this.torpedoes <= 0;
   }
 
   public int getNumberOfTorpedos() {
-    return this.torpedos;
+    return this.torpedoes;
   }
 }

--- a/src/test/java/hu/bme/mit/spaceship/GT4500Test.java
+++ b/src/test/java/hu/bme/mit/spaceship/GT4500Test.java
@@ -1,7 +1,6 @@
 package hu.bme.mit.spaceship;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,22 +15,22 @@ public class GT4500Test {
   }
 
   @Test
-  public void fireTorpedos_Single_Success(){
+  public void fireTorpedoes_Single_Success(){
     // Arrange
 
     // Act
-    boolean result = ship.fireTorpedos(FiringMode.SINGLE);
+    boolean result = ship.fireTorpedoes(FiringMode.SINGLE);
 
     // Assert
     assertEquals(true, result);
   }
 
   @Test
-  public void fireTorpedos_All_Success(){
+  public void fireTorpedoes_All_Success(){
     // Arrange
 
     // Act
-    boolean result = ship.fireTorpedos(FiringMode.ALL);
+    boolean result = ship.fireTorpedoes(FiringMode.ALL);
 
     // Assert
     assertEquals(true, result);


### PR DESCRIPTION
The plural of `torpedo` is `torpedoes`.